### PR TITLE
🐛(keycloak) remove extra environment variable definition

### DIFF
--- a/apps/keycloak/templates/services/app/deploy.yml.j2
+++ b/apps/keycloak/templates/services/app/deploy.yml.j2
@@ -61,9 +61,6 @@ spec:
               path: /auth/realms/master
               port: {{ keycloak_app_port }}
             initialDelaySeconds: 60
-          env:
-            - name: PROXY_ADDRESS_FORWARDING
-              value: "true"
           envFrom:
             - secretRef:
                 name: "{{ keycloak_secret_name }}"


### PR DESCRIPTION
## Purpose

There should be one, and only one single way to define the PROXY_ADDRESS_FORWARDING environment variable.

## Proposal

- [x] remove deployment definition
