### PR TITLE
✨(apps) add acme_enabled_route_prefix support

### DIFF
--- a/apps/grafana/CHANGELOG.md
+++ b/apps/grafana/CHANGELOG.md
@@ -8,8 +8,11 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.0] - 2021-12-03
+
 ### Added
 
-- First grafana 8.0.3 release
+- First Grafana release
 
-[Unreleased]: https://github.com/openfun/arnold-apps/
+[Unreleased]: https://github.com/openfun/arnold-apps/compare/grafana-v1.0.0...main
+[1.0.0]: https://github.com/openfun/arnold-apps/compare/74e2e72...grafana-v1.0.0

--- a/apps/grafana/templates/services/app/ingress.yml.j2
+++ b/apps/grafana/templates/services/app/ingress.yml.j2
@@ -11,7 +11,9 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
 {% if grafana_app_ip_whitelist | length %}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ grafana_app_ip_whitelist | join(',') }}"
 {% endif %}

--- a/apps/grafana/tray.yml
+++ b/apps/grafana/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: grafana
-  version: 7.5.7
+  version: 1.0.0

--- a/apps/jupyter/templates/services/app/ingress.yml.j2
+++ b/apps/jupyter/templates/services/app/ingress.yml.j2
@@ -8,7 +8,9 @@ metadata:
     service: app
     version: "{{ jupyter_image_tag }}"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
 {% if jupyter_app_ip_whitelist | length %}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ jupyter_app_ip_whitelist | join(',') }}"
 {% endif %}

--- a/apps/keycloak/CHANGELOG.md
+++ b/apps/keycloak/CHANGELOG.md
@@ -8,8 +8,11 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.0] - 2021-12-03
+
 ### Added
 
-- Add Keycloak 14.0
+- First Keycloak release
 
-[Unreleased]: https://github.com/openfun/arnold-apps/
+[Unreleased]: https://github.com/openfun/arnold-apps/compare/keycloak-v1.0.0...main
+[1.0.0]: https://github.com/openfun/arnold-apps/compare/74e2e72...keycloak-v1.0.0

--- a/apps/keycloak/templates/services/app/ingress.yml.j2
+++ b/apps/keycloak/templates/services/app/ingress.yml.j2
@@ -11,7 +11,9 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
 {% if keycloak_app_ip_whitelist | length %}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ keycloak_app_ip_whitelist | join(',') }}"
 {% endif %}

--- a/apps/keycloak/tray.yml
+++ b/apps/keycloak/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: keycloak
-  version: 14.0.0
+  version: 1.0.0


### PR DESCRIPTION
## Purpose

Arnold can activate ACME support on selected routes, this is convenient to avoid requesting SSL certificates for routes / ingresses that have no DNS entries.

## Proposal

- [x] add `acme_enabled_route_prefix` for grafana
- [x] add `acme_enabled_route_prefix` for keycloak
- [x] add `acme_enabled_route_prefix` for jupyter
