### PR TITLE
👷(circleci) migrate to machine image stable release

### DIFF
--- a/.circleci/apps.yml
+++ b/.circleci/apps.yml
@@ -28,10 +28,11 @@ jobs:
             ~/.local/bin/gitlint --commits origin/main..HEAD
 
   check-changelog:
-    # We use the machine executor, i.e. a VM, not a container
-    machine:
-      # Prevent cache-related issues
-      docker_layer_caching: false
+    docker:
+      - image: circleci/buildpack-deps:buster-scm
+        auth:
+          username: $DOCKER_HUB_USER
+          password: $DOCKER_HUB_PASSWORD
     working_directory: ~/fun
 
     steps:
@@ -62,6 +63,7 @@ jobs:
   test-bootstrap-app:
     # We use the machine executor, i.e. a VM, not a container
     machine:
+      image: ubuntu-2004:202201-02
       # Prevent cache-related issues
       docker_layer_caching: false
     working_directory: ~/fun


### PR DESCRIPTION
## Purpose

CircleCI will soon deprecate default base image for the machine executor.

## Proposal

We need to explicitly switch to the latest image stable release.

For more information about this migration please, refer to the migration guide:

https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/
