### PR TITLE
✨(grafana) add post deployment hooks support

### DIFF
--- a/.circleci/apps.yml
+++ b/.circleci/apps.yml
@@ -85,15 +85,15 @@ jobs:
       - run:
           name: Install the kubectl client and k3d
           command: |
-            export KUBECTL_RELEASE="v1.20.2"
+            export KUBECTL_RELEASE="v1.23.5"
             curl -Lo "${HOME}/bin/kubectl" "https://dl.k8s.io/release/${KUBECTL_RELEASE}/bin/linux/amd64/kubectl"
             curl -Lo /tmp/kubectl.sha256 "https://dl.k8s.io/${KUBECTL_RELEASE}/bin/linux/amd64/kubectl.sha256"
             echo "$(</tmp/kubectl.sha256) ${HOME}/bin/kubectl" | sha256sum --check
             chmod 755 "${HOME}/bin/kubectl"
 
-            export K3D_RELEASE="v4.2.0"
-            curl -Lo "${HOME}/bin/k3d" "https://github.com/rancher/k3d/releases/download/${K3D_RELEASE}/k3d-linux-amd64"
-            curl -sL https://github.com/rancher/k3d/releases/download/${K3D_RELEASE}/sha256sum.txt | \
+            export K3D_RELEASE="v4.4.8"
+            curl -Lo "${HOME}/bin/k3d" "https://github.com/k3d-io/k3d/releases/download/${K3D_RELEASE}/k3d-linux-amd64"
+            curl -sL https://github.com/k3d-io/k3d/releases/download/${K3D_RELEASE}/sha256sum.txt | \
               grep _dist/k3d-linux-amd64 | \
               sed "s|_dist/k3d-linux-amd64|${HOME}/bin/k3d|" | \
               sha256sum --check

--- a/apps/grafana/CHANGELOG.md
+++ b/apps/grafana/CHANGELOG.md
@@ -8,6 +8,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Implement support for post-deployment hook scripts as sidecar containers
+
 ## [1.0.0] - 2021-12-03
 
 ### Added

--- a/apps/grafana/CHANGELOG.md
+++ b/apps/grafana/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.0] - 2022-04-12
+
 ### Added
 
 - Implement support for post-deployment hook scripts as sidecar containers
@@ -18,5 +20,6 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 - First Grafana release
 
-[Unreleased]: https://github.com/openfun/arnold-apps/compare/grafana-v1.0.0...main
+[Unreleased]: https://github.com/openfun/arnold-apps/compare/grafana-v1.1.0...main
+[1.1.0]: https://github.com/openfun/arnold-apps/compare/grafana-v1.0.0...grafana-v1.1.0
 [1.0.0]: https://github.com/openfun/arnold-apps/compare/74e2e72...grafana-v1.0.0

--- a/apps/grafana/templates/services/app/deploy.yml.j2
+++ b/apps/grafana/templates/services/app/deploy.yml.j2
@@ -93,6 +93,21 @@ spec:
             - name: grafana-provisioning-dashboards
               mountPath: /etc/grafana/provisioning/dashboards/dashboards.yml
               subPath: dashboards.yml
+{% if grafana_activate_hooks %}
+        - name: hooks
+          image: "{{ grafana_hooks_image_name }}:{{ grafana_hooks_image_tag }}"
+          imagePullPolicy: Always
+          command: {{ grafana_hooks_commands }}
+          envFrom:
+            - secretRef:
+                name: "{{ grafana_secret_name }}"
+            - configMapRef:
+                name: "grafana-app-dotenv-{{ deployment_stamp }}"
+          resources: {{ grafana_hooks_resources }}
+          volumeMounts:
+            - mountPath: /var/lib/grafana
+              name: grafana-resources
+{% endif %}
       securityContext:
         runAsUser: {{ grafana_container_uid }}
         runAsGroup: {{ grafana_container_gid }}

--- a/apps/grafana/tray.yml
+++ b/apps/grafana/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: grafana
-  version: 1.0.0
+  version: 1.1.0

--- a/apps/grafana/vars/all/main.yml
+++ b/apps/grafana/vars/all/main.yml
@@ -33,6 +33,13 @@ grafana_dashboards_providers: []
 # Datasources providers
 # https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources
 grafana_datasources_providers: []
+# Hooks
+# If activated, hooks allow to modify provided dashboards or datasources
+# (post deployment).
+grafana_activate_hooks: false
+grafana_hooks_image_name: "fundocker/curl-jq"
+grafana_hooks_image_tag: latest
+grafana_hooks_commands: []
 
 # -- resources requests
 grafana_app_resources:
@@ -41,6 +48,11 @@ grafana_app_resources:
     memory: 750Mi
 
 grafana_postgresql_resources:
+  requests:
+    cpu: 10m
+    memory: 100Mi
+
+grafana_hooks_resources:
   requests:
     cpu: 10m
     memory: 100Mi


### PR DESCRIPTION
## Purpose

Some dashboards may require to be modified once deployed by injecting grafana database values in their source.

## Proposal

Those hooks are scripts distributed along with compiled dashboards and will be executed in a side-car container so that it can access to the temporary volume used to provision dashboards. This requires post-deployment hooks scripts to be idempotent.
